### PR TITLE
Updating werkzeug_version to 0.15.4 to fix an issue with python 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ MarkupSafe==0.23
 requests==2.11.1
 simplejson==3.8.2
 six==1.10.0
-Werkzeug==0.11.11
+Werkzeug==0.15.4


### PR DESCRIPTION
Opening the pull request to get the werkzeug version fixed in requirements.txt  for python 3.6. I was getting following error while running users.py and todo.py :

ImportError: cannot import name 'ForkingMixIn'

Stackoverflow Link describing the issue

https://stackoverflow.com/questions/39214395/running-flask-dev-server-in-python-3-6-raises-importerror-for-socketserver-and-f/39214538#39214538
